### PR TITLE
Fix cargo tarpaulin command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ script:
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
     cargo install cargo-tarpaulin &&
-    cargo tarpaulin --no-count -skip-clean --out Xml &&
+    cargo tarpaulin --no-count --skip-clean --out Xml &&
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+sudo: required
 dist: trusty
 addons:
     apt:


### PR DESCRIPTION
Previous to this PR, the cargo tarpaulin command failed with:

```
error: Found argument '-s' which wasn't expected, or isn't valid in this context
USAGE:
    cargo tarpaulin --no-count
For more information try --help
```

After this PR, the cargo tarpaulin command runs but is unable to collect coverage due to:

```
ASLR disable failed: EPERM: Operation not permitted
thread 'main' panicked at 'Failed to trace: Sys(EPERM)', /checkout/src/libcore/result.rs:906:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```